### PR TITLE
Fix CanvasAPI language tag and stylize names

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 				<ul>
 					<li><a href="#our_featured_open_source_projects">Projects</a></li>
 					<li><a href="#our_platforms_and_technologies">Community</a></li>
-					<li><a href="https://github.com/ucfopen" rel="nofollow" target="_blank">Github</a></li>
+					<li><a href="https://github.com/ucfopen" rel="nofollow" target="_blank">GitHub</a></li>
 					<li><a href="https://ucf-open-slackin.herokuapp.com/" rel="nofollow" target="_blank">Slack</a></li>
 				</ul>
 			</nav>
@@ -104,12 +104,12 @@
 					</div>
 
 					<div class="project project-canvasapi">
-						<h3><a href="https://github.com/ucfopen/canvasapi" rel="nofollow" target="_blank">Canvas API</a></h3>
+						<h3><a href="https://github.com/ucfopen/canvasapi" rel="nofollow" target="_blank">CanvasAPI</a></h3>
 						<p>
 							Python API wrapper for Instructure's Canvas LMS. Easily manage courses, users, gradebooks, and more.
 						</p>
 						<div class="tags">
-							<span class="tag tag-php">PHP</span>
+							<span class="tag tag-python">Python</span>
 							<span class="tag tag-MIT">MIT</span>
 						</div>
 					</div>
@@ -158,12 +158,12 @@
 				<div class="platform-container">
 					<div class="platform platform-github">
 						<div class="img-container">
-							<img src="img/github-logo.svg" alt="Github Logo" />
+							<img src="img/github-logo.svg" alt="GitHub Logo" />
 						</div>
 						<div class="platform-content">
-							<h3><a href="https://github.com/ucfopen" rel="nofollow" target="_blank">Github</a></h3>
-							<p>Our Open Source licensed code is hosted on Github. Download, and contribute!</p>
-							<a href="https://github.com/ucfopen" rel="nofollow" target="_blank">UCF Open Github</a>
+							<h3><a href="https://github.com/ucfopen" rel="nofollow" target="_blank">GitHub</a></h3>
+							<p>Our Open Source licensed code is hosted on GitHub. Download, and contribute!</p>
+							<a href="https://github.com/ucfopen" rel="nofollow" target="_blank">UCF Open GitHub</a>
 						</div>
 					</div>
 
@@ -212,12 +212,12 @@
 					<h1><a class="logo" href="/">UCF Open</a></h1>
 					<p>
 						UCF Open is the home for licensed open source software created at <a href="https://www.ucf.edu/" target="_blank">The University of Central Florida</a>.
-						If you have a project you'd like to share, license, or contribute, <a href="https://ucf-open-slackin.herokuapp.com/" rel="nofollow" target="_blank">contact us on Slack</a>
+						If you have a project you'd like to share, license, or contribute, <a href="https://ucf-open-slackin.herokuapp.com/" rel="nofollow" target="_blank">contact us on Slack.</a>
 					</p>
 				</div>
 				<h2>Get connected</h2>
 				<ul class="footer-links">
-					<li><a href="https://github.com/ucfopen" class="logolink logolink-github" rel="nofollow" target="_blank">Github</a></li>
+					<li><a href="https://github.com/ucfopen" class="logolink logolink-github" rel="nofollow" target="_blank">GitHub</a></li>
 					<li>
 						<a
 							href="https://ucf-open-slackin.herokuapp.com/"

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
 							A self-service LTI for faculty to easily extend time for multiple users for all quizzes at once.
 						</p>
 						<div class="tags">
-							<span class="tag tag-js">JavaScript</span>
+							<span class="tag tag-python">Python</span>
 							<span class="tag tag-MIT">MIT</span>
 						</div>
 					</div>


### PR DESCRIPTION
Modifies CanvasAPI's name to "CanvasAPI" from "Canvas API" and updates its language tag from PHP to Python.

This also stylizes GitHub correctly (with an uppercase H as opposed to a lowercase h). 