### PR TITLE
Fixed techrangers link

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 				</h2>
 				<div>
 						<p>
-							This initiative is maintained by the <a href="https://https://techrangers.cdl.ucf.edu" target="_blank">Techrangers</a> from <a href="https://digitallearning.ucf.edu/" target="_blank">The Division of Digital Learning</a> at UCF.  The Techrangers create many of the projects highlighted here, but UCF Open was created to highlight officially licensed open source software from anywhere within the university. This includes all UCF organizations, staff, faculty, and special student projects.
+							This initiative is maintained by the <a href="https://techrangers.cdl.ucf.edu" target="_blank">Techrangers</a> from <a href="https://digitallearning.ucf.edu/" target="_blank">The Division of Digital Learning</a> at UCF.  The Techrangers create many of the projects highlighted here, but UCF Open was created to highlight officially licensed open source software from anywhere within the university. This includes all UCF organizations, staff, faculty, and special student projects.
 						</p>
 						<p>
 							If you have a project you'd like to share, license, or contribute, <a href="https://ucf-open-slackin.herokuapp.com/" rel="nofollow" target="_blank">contact us on Slack</a>.


### PR DESCRIPTION
The link to techrangers.cdl.ucf.edu was broken, so I fixed the typo.